### PR TITLE
encode_json => wp_encode_json (v4.x comptability)

### DIFF
--- a/class-ghost.php
+++ b/class-ghost.php
@@ -507,7 +507,7 @@ class Ghost {
 	 * @return string		   output json
 	 */
 	public function get_json( $thearray ) {
-		return json_encode( $thearray );
+		return wp_json_encode( $thearray );
 	}
 
 


### PR DESCRIPTION
In 4.x versions (4.6.1 to be exact) `encode_json` returns false and an empty array is returned and save in a zero bytes file. Switching to wp_encode_json resolves this problem.