### PR TITLE
Add support for Ghost 2.x

### DIFF
--- a/class-ghost.php
+++ b/class-ghost.php
@@ -25,7 +25,7 @@ class Ghost {
 	 *
 	 * @var	 string
 	 */
-	protected $version = '0.5.6';
+	protected $version = '0.5.7';
 
 	/**
 	 * Unique identifier for your plugin.
@@ -248,7 +248,7 @@ class Ghost {
 	private function populate_meta() {
 		$this->garray['meta'] = array(
 			'exported_on' 	=> date( 'r' ),
-			'version'		=> '000',
+			'version'		=> '2.14.0',
 		);
 	}
 
@@ -334,7 +334,7 @@ class Ghost {
 					'slug'			=> substr( ( empty( $post->post_name ) ) ? 'temp-slug-' . $slug_number : $post->post_name, 0, 150 ),
 					'markdown'		=> $post->post_markdown->output(),
 					'html'			=> apply_filters( 'the_content', $post->post_content ),
-					'image'			=> ( $image_id ) ? $image[0] : null,
+					'feature_image'		=> ( $image_id ) ? $image[0] : null,
 					'featured'		=> 0,
 					'page'			=> ( $post->post_type === 'page' ) ? 1 : 0,
 					'status'		=> substr( $s, 0, 150 ),
@@ -396,7 +396,8 @@ class Ghost {
 				'created_at' => $this->_get_json_date( $user->user_registered ),
 				'created_by' => 1,
 				'email' => $user->user_email,
-				'name' => $user->user_nicename,
+				'name' => $user->display_name,
+				'profile_image' => get_avatar_url( $user->ID, [ 'size' => 512 ] ),
 			);
 		}
 

--- a/css/admin.css
+++ b/css/admin.css
@@ -44,6 +44,11 @@
 	list-style-position: outside;
 }
 
+#ghost ul {
+  list-style-type: lower-latin;
+  padding: 0 1em;
+}
+
 #ghost a {
 	color: #5ba4e5;
 	text-decoration: none;

--- a/views/admin.php
+++ b/views/admin.php
@@ -32,8 +32,20 @@
 		<li><strong>New in 0.5.3: </strong>Featured images are exported. They need to be uploaded to Cloudinary first!</li>
 	</ol>
 	<h3>Let's export data!</h3>
+	<p><strong>Heads-up! </strong>Pay attention to Step 2. It's a new step, to convert posts to Ghost's new "mobiledoc" format. If you skip this step, your posts will be imported, but won't have any content in them!</p>
 	<ol>
 		<li>Once you've moved media and comments into the cloud, it's time to press the blue "Download Ghost file" button. You will receive a <code>.json</code> file.</li>
+		<li>
+			This plugin only exports HTML and Markdown. You will have to convert it to Ghost's mobiledoc format through the following steps:
+			<ol>
+				<li>Make sure you have NodeJS v1.10 or later installed</li>
+				<li>Install the Ghost command-line tool using <code>npm install @tryghost/migrate -g</code></li>
+				<li>Run the command <code>migrate json html yourfile.json</code> to do the conversion</li>
+				<li>You will now find a new file called <code>ghost-import.json</code>, which has the updated formatting</li>
+				<li>Once you're done, you can remove the migration tool using <code>npm uninstall @tryghost/migrate -g</code></li>
+			</ol>
+			All finished? Then congratulations, you're ready for import!
+		</li>
 		<li>Next up spin up your Ghost installation, create a user, or sign in, if you already have an account, navigate to http://yourblogadress/ghost/debug/, and import the posts from the file.</li>
 		<li>You may or may not be logged out at the end of this procedure, depends on the ammount of posts you're moving over. More posts tend not to log you out.</li>
 	</ol>


### PR DESCRIPTION
Updated the script so it can work with the new versions of Ghost
* Changed fields and layout to work with Ghost 2.14
* Implemented profile pic ("avatar") import for users

As of now, this keeps `html` fields instead of `mobiledoc`, so it will have to be run through Ghost's migration tool as described [here](https://ghost.org/docs/api/v2/migration/#converting-html) before it can be imported (if not, the content of posts will be empty).