### PR TITLE
Fix HTML-encoded entities in titles

### DIFF
--- a/class-ghost.php
+++ b/class-ghost.php
@@ -346,7 +346,7 @@ class Ghost {
 
 				$this->garray['data']['posts'][] = array(
 					'id'				=> intval( $post->ID ),
-					'title'				=> substr( ( empty( $post->post_title ) ) ? '(untitled)' : $post->post_title, 0, 150 ),
+					'title'				=> substr( ( empty( $post->post_title ) ) ? '(untitled)' : html_entity_decode( $post->post_title ), 0, 150 ),
 					'slug'				=> substr( ( empty( $post->post_name ) ) ? 'temp-slug-' . $slug_number : $post->post_name, 0, 150 ),
 					'mobiledoc' 		=> '{"version":"0.3.1","atoms":[],"cards":[["html",{"html":"'.str_replace(
 						array(


### PR DESCRIPTION
Currently, `&amp;` and other entities come over to Ghost as plaintext

Closes #31
