### PR TITLE
Updated integrations link for community subtype in README

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ The Ghost Migrator plugin will export as much blog and publication data as it ca
 
 - Posts, pages, tags and authors are all automatically exported and recreated for Ghost
 - Tags will be migrated, but not categories. If needed you can [convert your categories to tags](https://wordpress.org/plugins/wpcat2tag-importer/) before exporting.
-- Ghost does not have built-in comments, but it does integrate with [many comment platforms](https://ghost.org/integrations/community/) if you want to migrate your comments there.
+- Ghost does not have built-in comments, but it does integrate with [many comment platforms](https://ghost.org/integrations/?tag=community) if you want to migrate your comments there.
 - No custom fields, meta, shortcodes, post types, taxonomies or binary files will be migrated. Just regular **posts**, **pages**, **tags** and **images**
 - Passwords are not migrated - after importing to Ghost, each user may perform a password reset to gain access to their Ghost account
 


### PR DESCRIPTION
Current link to Ghost integrations related to community ([many comment platforms](https://ghost.org/integrations/community/)) 404s. Replace with tag query string.