### PR TITLE
README: Reflect that categories are now migrated and that Ghost has comments now.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,9 +20,9 @@ The official Ghost plugin allows you to export your WordPress data in a JSON for
 
 The Ghost Migrator plugin will export as much blog and publication data as it can into a clean set of exported files.
 
-- Posts, pages, tags and authors are all automatically exported and recreated for Ghost
-- Tags will be migrated, but not categories. If needed you can [convert your categories to tags](https://wordpress.org/plugins/wpcat2tag-importer/) before exporting.
-- Ghost does not have built-in comments, but it does integrate with [many comment platforms](https://ghost.org/integrations/?tag=community) if you want to migrate your comments there.
+- Posts, pages, categories, tags and authors are all automatically exported and recreated for Ghost
+- Categories will be converted to tags.
+- Ghost has built-in comments, but comments are not migrated.
 - No custom fields, meta, shortcodes, post types, taxonomies or binary files will be migrated. Just regular **posts**, **pages**, **tags** and **images**
 - Passwords are not migrated - after importing to Ghost, each user may perform a password reset to gain access to their Ghost account
 

--- a/readme.txt
+++ b/readme.txt
@@ -21,7 +21,7 @@ The official Ghost plugin allows you to export your WordPress data in a JSON for
 The Ghost Migrator plugin will export as much blog and publication data as it can into a clean set of exported files.
 
 - Posts, pages, categories, tags and authors are all automatically exported and recreated for Ghost
-- Categories will be converted to tags.
+- Categories will be converted to tags. They appear first in the tag list, in the order that WordPress returns them. An internal "#wordpress" tag will be added to all exported posts so they can be easily found later. This tag is not visible to users.
 - Ghost has built-in comments, but comments are not migrated.
 - No custom fields, meta, shortcodes, post types, taxonomies or binary files will be migrated. Just regular **posts**, **pages**, **tags** and **images**
 - Passwords are not migrated - after importing to Ghost, each user may perform a password reset to gain access to their Ghost account


### PR DESCRIPTION
There are several mentions in the README to "WorePress", which I did not correct in this comment, but I presume are not intentional. 

Also:

- Clarify what will become the primary tag
- Document #wordpress tag being added.